### PR TITLE
feat: add dark mode and meal history

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -200,6 +200,49 @@ Button:disabled {
   cursor: not-allowed; /* Ejemplo: cambiar el cursor a "no permitido" */
 }
 
+#historial-container {
+  margin-top: 20px;
+}
+
+#historial li {
+  margin-bottom: 5px;
+}
+
+body.dark-mode {
+  background-color: #121212;
+  color: #ffffff;
+}
+
+body.dark-mode .form-control {
+  background-color: #343a40;
+  color: #ffffff;
+  border-color: #495057;
+}
+
+body.dark-mode .anotacion {
+  color: #bbbbbb;
+}
+
+body.dark-mode button {
+  background-color: #0d6efd;
+  color: #ffffff;
+}
+
+body.dark-mode button:hover {
+  background-color: #0b5ed7;
+}
+
+body.dark-mode .export-button {
+  background-color: #bb86fc;
+  color: #000000;
+}
+
+body.dark-mode .export-button:hover {
+  background-color: #ffffff;
+  color: #bb86fc;
+  border: 2px solid #bb86fc;
+}
+
 
 
 

--- a/index.html
+++ b/index.html
@@ -46,11 +46,19 @@
         "
       >
         <h1>Calculadora de Raciones</h1>
-        <i
-          id="aboutIcon"
-          class="fa-solid fa-circle-info"
-          style="cursor: pointer"
-        ></i>
+        <div>
+          <i
+            id="themeToggle"
+            class="fa-solid fa-moon"
+            style="cursor: pointer; margin-right: 10px"
+            title="Cambiar tema"
+          ></i>
+          <i
+            id="aboutIcon"
+            class="fa-solid fa-circle-info"
+            style="cursor: pointer"
+          ></i>
+        </div>
       </div>
       <h5 id="numero-alimentos"></h5>
       <p class="anotacion">
@@ -103,6 +111,19 @@
                 onclick="limpiar()"
               >
                 Limpiar
+              </button>
+              <button
+                type="button"
+                class="btn btn-secondary col-lg-2 mx-2"
+                style="
+                  max-width: 100px;
+                  min-width: 100px;
+                  border-radius: 0px;
+                  max-height: 40px;
+                "
+                onclick="agregarAlimento()"
+              >
+                Añadir
               </button>
             </div>
           </div>
@@ -166,10 +187,21 @@
         <div id="suma-resultado"></div>
       </div>
       <div id="resultado"></div>
+      <div id="historial-container" class="mt-4">
+        <h2>Historial</h2>
+        <ul id="historial"></ul>
+        <button
+          class="export-button mt-2"
+          onclick="exportarPDF()"
+        >
+          Exportar historial a PDF
+        </button>
+      </div>
     </div>
     <script src="js/jquery-3.7.0.min.js"></script>
     <script src="js/jquery-ui.min.js"></script>
     <script src="js/quagga.min.js"></script>
+    <script src="js/jspdf.min.js"></script>
     <script src="js/scripts.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add dark mode toggle and persistent theme
- allow adding custom foods and track meal history with PDF export

## Testing
- `node --check js/scripts.js`
- `python -m py_compile js/scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_68b943a00e0c83238bcc32f9b7e74460